### PR TITLE
PI-1494: Add getDate function to get ntp date based on the given offset

### DIFF
--- a/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
+++ b/.swiftpm/xcode/package.xcworkspace/contents.xcworkspacedata
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Workspace
+   version = "1.0">
+   <FileRef
+      location = "self:">
+   </FileRef>
+</Workspace>


### PR DESCRIPTION
https://prex.atlassian.net/browse/PI-1494

I believe the reason of the delay is caused by the lock process in `now` variable. So, my solution is to pass the `offset` to the client side, so that Kronos SDK don't have to handle the concurrency access.