### PR TITLE
PI-1572: Add Privacy Manifest in Kronos

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ xcuserdata
 Packages/
 
 bazel-*
+
+# Swift Package Manager
+.swiftpm/

--- a/Kronos.podspec
+++ b/Kronos.podspec
@@ -13,4 +13,6 @@ Pod::Spec.new do |s|
   s.tvos.deployment_target = '12.0'
 
   s.source_files = 'Sources/*.swift'
+  
+  s.resource_bundles = {'Kronos' => ['Source/PrivacyInfo.xcprivacy']}
 end

--- a/Kronos.xcodeproj/project.pbxproj
+++ b/Kronos.xcodeproj/project.pbxproj
@@ -49,6 +49,7 @@
 		26447D861D6E54FF00159BEE /* DNSResolverTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = DNSResolverTests.swift; sourceTree = "<group>"; };
 		26447D871D6E54FF00159BEE /* NTPClientTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NTPClientTests.swift; sourceTree = "<group>"; };
 		26447D881D6E54FF00159BEE /* NTPPacketTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = NTPPacketTests.swift; sourceTree = "<group>"; };
+		5DB5A05F2BAAF67D0069CCF9 /* PrivacyInfo.xcprivacy */ = {isa = PBXFileReference; lastKnownFileType = text.xml; path = PrivacyInfo.xcprivacy; sourceTree = "<group>"; };
 		930B39DC2051E6D300360BA2 /* TimeStorage.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeStorage.swift; sourceTree = "<group>"; };
 		930B39DE2051F25300360BA2 /* TimeStorageTests.swift */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.swift; path = TimeStorageTests.swift; sourceTree = "<group>"; };
 		C20174831BD5509D00E4FE18 /* Kronos.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Kronos.framework; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -122,6 +123,7 @@
 				26447D7A1D6E54D400159BEE /* NTPProtocol.swift */,
 				26447D7B1D6E54D400159BEE /* TimeFreeze.swift */,
 				930B39DC2051E6D300360BA2 /* TimeStorage.swift */,
+				5DB5A05F2BAAF67D0069CCF9 /* PrivacyInfo.xcprivacy */,
 			);
 			path = Sources;
 			sourceTree = "<group>";

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.0
+// swift-tools-version:5.3
 import PackageDescription
 
 let package = Package(
@@ -7,7 +7,11 @@ let package = Package(
         .library(name: "Kronos", targets: ["Kronos"]),
     ],
     targets: [
-        .target(name: "Kronos", path: "Sources"),
+        .target(
+            name: "Kronos",
+            path: "Sources",
+            resources: [.process("PrivacyInfo.xcprivacy")]
+        ),
         .testTarget(name: "KronosTests", dependencies: ["Kronos"]),
     ]
 )

--- a/Sources/PrivacyInfo.xcprivacy
+++ b/Sources/PrivacyInfo.xcprivacy
@@ -1,0 +1,23 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>NSPrivacyAccessedAPITypes</key>
+	<array>
+		<dict>
+			<key>NSPrivacyAccessedAPIType</key>
+			<string>NSPrivacyAccessedAPICategoryUserDefaults</string>
+			<key>NSPrivacyAccessedAPITypeReasons</key>
+			<array>
+				<string>CA92.1</string>
+			</array>
+		</dict>
+	</array>
+	<key>NSPrivacyCollectedDataTypes</key>
+	<array/>
+	<key>NSPrivacyTrackingDomains</key>
+	<array/>
+	<key>NSPrivacyTracking</key>
+	<false/>
+</dict>
+</plist>


### PR DESCRIPTION
- Add PrivacyInfo.xcprivacy to Kronos.xcoproj.
- Add in the Privacy Manifest UserDefaults API with reason CA92.1.
- Include PRivacyInfo.xcprivacy file in the Package.swift.
- Upgrade minimum version of swift-tools-version to accept resources in Targets.
- Include PrivacyInfo.xcprivacy file in Pods file.