### PR TITLE
PI-1576: Replace thread-unsafe syscalls.

### DIFF
--- a/Sources/NTPPacket.swift
+++ b/Sources/NTPPacket.swift
@@ -13,9 +13,10 @@ private let kMaximumDispersion = 100.0
 /// - returns: The current time in EPOCH timestamp format.
 func currentTime() -> TimeInterval {
     var current = timeval()
+    /// Thread-safe reference (section 2.9.1): https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
+    /// Apple Engineer's explanation: https://forums.developer.apple.com/forums/thread/749390?answerId=784240022#784240022
     let systemTimeError = gettimeofday(&current, nil) != 0
     assert(!systemTimeError, "system clock error: system time unavailable")
-
     return Double(current.tv_sec) + Double(current.tv_usec) / 1_000_000
 }
 

--- a/Sources/TimeStorage.swift
+++ b/Sources/TimeStorage.swift
@@ -23,7 +23,7 @@ public enum TimeStoragePolicy {
 /// Handles saving and retrieving instances of `TimeFreeze` for quick retrieval
 public struct TimeStorage {
     private var userDefaults: UserDefaults
-    private let kDefaultsKey = "KronosStableTime"
+    private let kDefaultsKey = "PrexKronosStableTimeStorageKey"
 
     /// The most recent stored `TimeFreeze`. Getting retrieves from the UserDefaults defined by the storage
     /// policy. Setting sets the value in UserDefaults


### PR DESCRIPTION
https://prex.atlassian.net/browse/PI-1576
- Change back to use `currentTime()` and use `gettimeofday` as it is thread-safe as confirmed by Apple team 
  - Apple forum: https://forums.developer.apple.com/forums/thread/749390?answerId=784240022#784240022
  - POSIX documentation section 2.9.1: https://pubs.opengroup.org/onlinepubs/9699919799/functions/V2_chap02.html
- get `systemUptime` using `sysctl` as it is thread-safe according to 
  - Apple engineer's confirmation: https://forums.developer.apple.com/forums/thread/749390?answerId=784240022#784240022
  - Code modification to prevent race condition when system trying to write a new time: https://stackoverflow.com/a/40497811/23930754
- Update UserDefault key name when storing and retrieving value, so that it works correctly