### PR TITLE
PI-2638: Remove error log from non-error scenario

### DIFF
--- a/Sources/Log.swift
+++ b/Sources/Log.swift
@@ -3,5 +3,4 @@ import Foundation
 public enum Log {
     case unmatchedUserDefaultsValue(value: String)
     case dictionaryValueNotFound(dictionary: [String: TimeInterval])
-    case invalidBootTime(currentUptime: TimeInterval, currentTimestamp: TimeInterval, currentBoot: TimeInterval, previousBoot: TimeInterval, dictionary: [String: TimeInterval])
 }

--- a/Sources/TimeFreeze.swift
+++ b/Sources/TimeFreeze.swift
@@ -44,7 +44,6 @@ struct TimeFreeze {
         let currentBoot = currentUptime - currentTimestamp
         let previousBoot = uptime - timestamp
         if rint(currentBoot) - rint(previousBoot) != 0 {
-            log?(.invalidBootTime(currentUptime: currentUptime, currentTimestamp: currentTimestamp, currentBoot: currentBoot, previousBoot: previousBoot, dictionary: dictionary))
             return nil
         }
 


### PR DESCRIPTION
https://prex.atlassian.net/browse/PI-2638
Remove this log because it is a valid scenario. When user restart their device and open the app again, the boot time will change, therefore we cannot reuse the timestamp stored in the `UserDefault` anymore and `ntpStoredTime` will become `nil`

This PR blocks another PR: https://github.com/teamprex/prex-ios/pull/3951