### PR TITLE
PI-11469: Migrate Kronos to Swift 6.1, harden InternetAddress.host, and stabilize tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,6 +14,7 @@
 ._*
 .AppleDouble
 .build/
+.swiftpm/
 .DS_Store
 .LSOverride
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -14,7 +14,6 @@
 ._*
 .AppleDouble
 .build/
-.swiftpm/
 .DS_Store
 .LSOverride
 build/

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,41 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## What this is
+
+Kronos is an NTP client library in Swift that provides a monotonic clock unaffected by device clock changes. This repo (`prex-ios-alien-kronos`) is Prex's fork of [MobileNativeFoundation/Kronos](https://github.com/MobileNativeFoundation/Kronos), with Prex-specific concurrency hardening (Swift 6 migration, `Clock2`).
+
+## Build & test
+
+The package builds three ways — SPM (`Package.swift`), Bazel (`MODULE.bazel`/`BUILD`), and CocoaPods (`Kronos.podspec`). Prefer SPM for local work:
+
+```bash
+swift build
+swift test                                    # all tests
+swift test --filter KronosTests.ClockTests    # single test class
+swift test --filter KronosTests.ClockTests/testFoo   # single test
+swiftlint lint --strict                        # lint (config: .swiftlint.yml)
+```
+
+Do **not** run `xcodebuild` — it is slow; ask the developer to test in Xcode instead. The `Makefile` targets (`make test-iOS`, `test-OSX`, `test-tvOS`) drive `xcodebuild` and are CI-oriented.
+
+The package uses `swift-tools-version:6.1` (Swift 6 language mode, strict concurrency on by default). Some tests in `Tests/KronosTests/` depend on live network NTP responses.
+
+## Architecture
+
+The flow is: **`Clock2.sync` → `NTPClient.query` → `DNSResolver` + `NTPPacket` over `CFSocket` UDP → `TimeFreeze` (monotonic offset) → `TimeStorage` (persistence).**
+
+- **`Clock2`** (`Sources/Clock2.swift`) — the clock used by Prex. An `enum` (namespace) whose mutable static state (`latestOffset`, `storage`, `_log`) is guarded by a single `NSLock` (`protection`); fields are `nonisolated(unsafe)` deliberately rather than converting to an actor, because the underlying `NTPClient` must run on the main thread. `sync`/`reset` are `@MainActor` and assert `Thread.isMainThread`; `now`/`offset`/`storedNow` are thread-safe getters. `now` recomputes from the stored offset on every call.
+- **`Clock`** (`Sources/Clock.swift`) — original upstream clock, **`@available(*, deprecated, renamed: "Clock2")`**. Kept for reference only; do not build new functionality on it.
+- **`NTPClient`** (`Sources/NTPClient.swift`) — resolves a pool to up to `kMaximumNTPServers` (5) addresses, fires `numberOfSamples` (4) recursive queries per server, and computes the final offset as the **median of the lowest-delay response per server** (after filtering by `kMaximumResultDispersion`). Networking is raw `CFSocket` UDP with manual `Unmanaged` retain/release bridging of an ObjC-block callback — handle this memory management carefully when editing.
+- **`TimeFreeze`** (`Sources/TimeFreeze.swift`) — the heart of monotonicity. `systemUptime()` derives a stable timestamp from kernel boot time (`sysctl KERN_BOOTTIME`) using a retry loop to avoid a race between reading boot time and wall-clock time (see the linked Apple-forum justifications in comments). Sub-second precision is intentionally lost due to a Darwin limitation. Persists/restores via dictionary; restore returns `nil` if the device has rebooted since.
+- **`TimeStorage`** (`Sources/TimeStorage.swift`) — `UserDefaults`-backed persistence. `TimeStoragePolicy` selects `.standard` or `.appGroup(...)` to share synced time between an app and its extensions.
+- **`NTPPacket`** / **`NTPProtocol`** — NTP PDU encode/decode and validation. **`InternetAddress`**, **`DNSResolver`**, **`Data+Bytes`**, **`NSTimer+ClosureKit`** are supporting socket/DNS/byte utilities.
+
+## Conventions
+
+- Concurrency: the codebase favors `NSLock` + `nonisolated(unsafe)` over actors (see `Clock2` rationale) because the socket layer is main-thread-bound. Per global rules, never use `@unchecked Sendable`.
+- `.swiftlint.yml` enforces a 110-char line length and mandatory trailing commas; `variable_name`, `nesting`, `opening_brace`, `valid_docs` are disabled (the code uses NTP-style short names like `PDU`).
+- Add a `CHANGELOG.md` entry for user-facing changes (per `CONTRIBUTING.md`).
+- `Sources/PrivacyInfo.xcprivacy` is shipped as a bundled resource — keep it in sync if data-use changes.

--- a/Package.swift
+++ b/Package.swift
@@ -1,4 +1,4 @@
-// swift-tools-version:5.9
+// swift-tools-version:6.1
 import PackageDescription
 
 let package = Package(

--- a/Package.swift
+++ b/Package.swift
@@ -16,9 +16,6 @@ let package = Package(
         ),
         .testTarget(
             name: "KronosTests",
-            dependencies: ["Kronos"],
-            swiftSettings: [
-                .enableUpcomingFeature("StrictConcurrency"),
-            ]),
+            dependencies: ["Kronos"]),
     ]
 )

--- a/Sources/InternetAddress.swift
+++ b/Sources/InternetAddress.swift
@@ -13,13 +13,15 @@ enum InternetAddress: Hashable {
         switch self {
         case .ipv6(var address):
             var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
-            inet_ntop(AF_INET6, &address.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
-            return buffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+            return buffer.withUnsafeMutableBufferPointer {
+                String(cString: inet_ntop(AF_INET6, &address.sin6_addr, $0.baseAddress, socklen_t($0.count))!)
+            }
 
         case .ipv4(var address):
             var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
-            inet_ntop(AF_INET, &address.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-            return buffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
+            return buffer.withUnsafeMutableBufferPointer {
+                String(cString: inet_ntop(AF_INET, &address.sin_addr, $0.baseAddress, socklen_t($0.count))!)
+            }
         }
     }
 

--- a/Sources/InternetAddress.swift
+++ b/Sources/InternetAddress.swift
@@ -14,13 +14,15 @@ enum InternetAddress: Hashable {
         case .ipv6(var address):
             var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
             return buffer.withUnsafeMutableBufferPointer {
-                String(cString: inet_ntop(AF_INET6, &address.sin6_addr, $0.baseAddress, socklen_t($0.count))!)
+                inet_ntop(AF_INET6, &address.sin6_addr, $0.baseAddress, socklen_t($0.count))
+                    .map { String(cString: $0) }
             }
 
         case .ipv4(var address):
             var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
             return buffer.withUnsafeMutableBufferPointer {
-                String(cString: inet_ntop(AF_INET, &address.sin_addr, $0.baseAddress, socklen_t($0.count))!)
+                inet_ntop(AF_INET, &address.sin_addr, $0.baseAddress, socklen_t($0.count))
+                    .map { String(cString: $0) }
             }
         }
     }

--- a/Sources/InternetAddress.swift
+++ b/Sources/InternetAddress.swift
@@ -14,12 +14,12 @@ enum InternetAddress: Hashable {
         case .ipv6(var address):
             var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
             inet_ntop(AF_INET6, &address.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
-            return String(cString: buffer)
+            return buffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
 
         case .ipv4(var address):
             var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
             inet_ntop(AF_INET, &address.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
-            return String(cString: buffer)
+            return buffer.withUnsafeBufferPointer { String(cString: $0.baseAddress!) }
         }
     }
 

--- a/Tests/KronosTests/ClockTests.swift
+++ b/Tests/KronosTests/ClockTests.swift
@@ -1,6 +1,8 @@
 import XCTest
 @testable import Kronos
 
+@MainActor
+@available(*, deprecated, message: "Exercises the deprecated Clock; kept for reference alongside Clock2.")
 final class ClockTests: XCTestCase {
 
     override func setUp() {

--- a/Tests/KronosTests/DNSResolverTests.swift
+++ b/Tests/KronosTests/DNSResolverTests.swift
@@ -4,10 +4,12 @@ import XCTest
 @MainActor
 final class DNSResolverTests: XCTestCase {
 
+    // Uses the IANA-reserved example.com and asserts > 0: an exact count tied to a third-party
+    // domain's DNS broke twice before (lyft.com grew extra A records, then test.com lost its A record).
     func testResolveOneIP() {
         let expectation = self.expectation(description: "Query host's DNS for a single IP")
-        DNSResolver.resolve(host: "test.com") { addresses in
-            XCTAssertEqual(addresses.count, 1)
+        DNSResolver.resolve(host: "example.com") { addresses in
+            XCTAssertGreaterThan(addresses.count, 0)
             expectation.fulfill()
         }
 

--- a/Tests/KronosTests/DNSResolverTests.swift
+++ b/Tests/KronosTests/DNSResolverTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Kronos
 
+@MainActor
 final class DNSResolverTests: XCTestCase {
 
     func testResolveOneIP() {

--- a/Tests/KronosTests/InternetAddressTests.swift
+++ b/Tests/KronosTests/InternetAddressTests.swift
@@ -22,4 +22,48 @@ final class InternetAddressTests: XCTestCase {
         XCTAssertEqual(internetAddress.host, "2001:db8::1")
         XCTAssertEqual(internetAddress.family, PF_INET6)
     }
+
+    /// `host` was migrated off the deprecated array-based `String(cString:)` overload to the
+    /// `UnsafePointer<CChar>` overload. This proves the migration produced identical output.
+    @available(*, deprecated, message: "Compares against the deprecated decoding path on purpose.")
+    func testHostMatchesLegacyCStringDecoding() {
+        let ipv4Addresses = ["0.0.0.0", "127.0.0.1", "192.168.1.1", "255.255.255.255", "8.8.8.8"]
+        for ip in ipv4Addresses {
+            var address = sockaddr_in()
+            address.sin_family = sa_family_t(AF_INET)
+            XCTAssertEqual(inet_pton(AF_INET, ip, &address.sin_addr), 1, "Failed to parse \(ip)")
+
+            let internetAddress = InternetAddress.ipv4(address)
+            XCTAssertEqual(internetAddress.host, legacyHost(internetAddress), "Mismatch for \(ip)")
+            XCTAssertEqual(internetAddress.host, ip)
+        }
+
+        let ipv6Addresses = ["::", "::1", "2001:db8::1", "fe80::1", "ff02::1"]
+        for ip in ipv6Addresses {
+            var address = sockaddr_in6()
+            address.sin6_family = sa_family_t(AF_INET6)
+            XCTAssertEqual(inet_pton(AF_INET6, ip, &address.sin6_addr), 1, "Failed to parse \(ip)")
+
+            let internetAddress = InternetAddress.ipv6(address)
+            XCTAssertEqual(internetAddress.host, legacyHost(internetAddress), "Mismatch for \(ip)")
+            XCTAssertEqual(internetAddress.host, ip)
+        }
+    }
+
+    /// Re-implements the pre-migration `host` getter verbatim using the deprecated array-based
+    /// `String(cString:)` overload, so the test can assert behavioral parity with the new path.
+    @available(*, deprecated, message: "Uses the deprecated String(cString: [CChar]) overload on purpose.")
+    private func legacyHost(_ address: InternetAddress) -> String? {
+        switch address {
+        case .ipv6(var addr):
+            var buffer = [CChar](repeating: 0, count: Int(INET6_ADDRSTRLEN))
+            inet_ntop(AF_INET6, &addr.sin6_addr, &buffer, socklen_t(INET6_ADDRSTRLEN))
+            return String(cString: buffer)
+
+        case .ipv4(var addr):
+            var buffer = [CChar](repeating: 0, count: Int(INET_ADDRSTRLEN))
+            inet_ntop(AF_INET, &addr.sin_addr, &buffer, socklen_t(INET_ADDRSTRLEN))
+            return String(cString: buffer)
+        }
+    }
 }

--- a/Tests/KronosTests/InternetAddressTests.swift
+++ b/Tests/KronosTests/InternetAddressTests.swift
@@ -38,7 +38,15 @@ final class InternetAddressTests: XCTestCase {
             XCTAssertEqual(internetAddress.host, ip)
         }
 
-        let ipv6Addresses = ["::", "::1", "2001:db8::1", "fe80::1", "ff02::1"]
+        let ipv6Addresses = [
+            "::",
+            "::1",
+            "2001:db8::1",
+            "fe80::1",
+            "ff02::1",
+            "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff",
+            "::ffff:255.255.255.255",
+        ]
         for ip in ipv6Addresses {
             var address = sockaddr_in6()
             address.sin6_family = sa_family_t(AF_INET6)
@@ -48,6 +56,98 @@ final class InternetAddressTests: XCTestCase {
             XCTAssertEqual(internetAddress.host, legacyHost(internetAddress), "Mismatch for \(ip)")
             XCTAssertEqual(internetAddress.host, ip)
         }
+    }
+
+    /// `host` force-unwraps `inet_ntop`, which can only fail with `ENOSPC` (output longer than the
+    /// buffer). These max-length inputs prove the buffers are sized so that failure can't happen, so
+    /// the force-unwrap never traps and `host` is never nil.
+    func testHostIsNonNilAtBufferSizeBoundary() {
+        // Longest IPv4 text form is 15 chars + NUL == INET_ADDRSTRLEN (16), the tightest buffer.
+        let ipv4Max = makeIPv4("255.255.255.255")
+        XCTAssertNotNil(ipv4Max.host)
+        XCTAssertEqual(ipv4Max.host, "255.255.255.255")
+        XCTAssertEqual(ipv4Max.host?.count, Int(INET_ADDRSTRLEN) - 1)
+
+        // Longest text form inet_ntop emits for IPv6 (all groups set) is 39 chars, within
+        // INET6_ADDRSTRLEN (46); confirm the conversion still succeeds at that extreme.
+        let ipv6Max = makeIPv6("ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+        XCTAssertNotNil(ipv6Max.host)
+        XCTAssertEqual(ipv6Max.host, "ffff:ffff:ffff:ffff:ffff:ffff:ffff:ffff")
+    }
+
+    func testEqualityComparesByHost() {
+        XCTAssertEqual(makeIPv4("192.168.1.1"), makeIPv4("192.168.1.1"))
+        XCTAssertNotEqual(makeIPv4("192.168.1.1"), makeIPv4("192.168.1.2"))
+        XCTAssertNotEqual(makeIPv4("127.0.0.1"), makeIPv6("::1"))
+    }
+
+    func testHashingMatchesHost() {
+        XCTAssertEqual(makeIPv4("10.0.0.1").hashValue, makeIPv4("10.0.0.1").hashValue)
+        let unique: Set<InternetAddress> = [
+            makeIPv4("10.0.0.1"),
+            makeIPv4("10.0.0.1"),
+            makeIPv4("10.0.0.2"),
+            makeIPv6("::1"),
+        ]
+        XCTAssertEqual(unique.count, 3)
+    }
+
+    func testInitFromDataRoundTripsIPv4() {
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        XCTAssertEqual(inet_pton(AF_INET, "10.20.30.40", &address.sin_addr), 1)
+        let data = Data(bytes: &address, count: MemoryLayout<sockaddr_in>.size) as NSData
+
+        let parsed = InternetAddress(dataWithSockAddress: data)
+        XCTAssertEqual(parsed?.host, "10.20.30.40")
+        XCTAssertEqual(parsed?.family, PF_INET)
+    }
+
+    func testInitFromDataRoundTripsIPv6() {
+        var address = sockaddr_in6()
+        address.sin6_family = sa_family_t(AF_INET6)
+        XCTAssertEqual(inet_pton(AF_INET6, "2001:db8::dead:beef", &address.sin6_addr), 1)
+        let data = Data(bytes: &address, count: MemoryLayout<sockaddr_in6>.size) as NSData
+
+        let parsed = InternetAddress(dataWithSockAddress: data)
+        XCTAssertEqual(parsed?.host, "2001:db8::dead:beef")
+        XCTAssertEqual(parsed?.family, PF_INET6)
+    }
+
+    func testInitFromDataReturnsNilForUnsupportedFamily() {
+        var storage = sockaddr_storage()
+        storage.ss_family = sa_family_t(AF_UNIX)
+        let data = Data(bytes: &storage, count: MemoryLayout<sockaddr_storage>.size) as NSData
+
+        XCTAssertNil(InternetAddress(dataWithSockAddress: data))
+    }
+
+    func testAddressDataEncodesPortAndRoundTrips() {
+        let original = makeIPv4("203.0.113.7")
+        let data = original.addressData(withPort: 123) as Data
+
+        var parsed = sockaddr_in()
+        _ = withUnsafeMutableBytes(of: &parsed) {
+            data.copyBytes(to: $0, count: MemoryLayout<sockaddr_in>.size)
+        }
+        XCTAssertEqual(UInt16(bigEndian: parsed.sin_port), 123)
+
+        let roundTripped = InternetAddress(dataWithSockAddress: data as NSData)
+        XCTAssertEqual(roundTripped?.host, "203.0.113.7")
+    }
+
+    private func makeIPv4(_ ip: String) -> InternetAddress {
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        precondition(inet_pton(AF_INET, ip, &address.sin_addr) == 1, "invalid IPv4 \(ip)")
+        return .ipv4(address)
+    }
+
+    private func makeIPv6(_ ip: String) -> InternetAddress {
+        var address = sockaddr_in6()
+        address.sin6_family = sa_family_t(AF_INET6)
+        precondition(inet_pton(AF_INET6, ip, &address.sin6_addr) == 1, "invalid IPv6 \(ip)")
+        return .ipv6(address)
     }
 
     /// Re-implements the pre-migration `host` getter verbatim using the deprecated array-based

--- a/Tests/KronosTests/InternetAddressTests.swift
+++ b/Tests/KronosTests/InternetAddressTests.swift
@@ -1,0 +1,25 @@
+import XCTest
+@testable import Kronos
+
+final class InternetAddressTests: XCTestCase {
+
+    func testIPv4Host() {
+        var address = sockaddr_in()
+        address.sin_family = sa_family_t(AF_INET)
+        XCTAssertEqual(inet_pton(AF_INET, "127.0.0.1", &address.sin_addr), 1)
+
+        let internetAddress = InternetAddress.ipv4(address)
+        XCTAssertEqual(internetAddress.host, "127.0.0.1")
+        XCTAssertEqual(internetAddress.family, PF_INET)
+    }
+
+    func testIPv6Host() {
+        var address = sockaddr_in6()
+        address.sin6_family = sa_family_t(AF_INET6)
+        XCTAssertEqual(inet_pton(AF_INET6, "2001:db8::1", &address.sin6_addr), 1)
+
+        let internetAddress = InternetAddress.ipv6(address)
+        XCTAssertEqual(internetAddress.host, "2001:db8::1")
+        XCTAssertEqual(internetAddress.family, PF_INET6)
+    }
+}

--- a/Tests/KronosTests/NTPClientTests.swift
+++ b/Tests/KronosTests/NTPClientTests.swift
@@ -30,8 +30,12 @@ final class NTPClientTests: XCTestCase {
 
             NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1)
             { offset2, _, _ in
-                XCTAssertNotNil(offset2)
-                XCTAssertLessThan(abs(offset! - offset2!), 0.10)
+                guard let offset, let offset2 else {
+                    XCTFail("NTP query returned no offset (network/UDP 123 blocked?)")
+                    expectation.fulfill()
+                    return
+                }
+                XCTAssertLessThan(abs(offset - offset2), 0.10)
                 expectation.fulfill()
             }
         }

--- a/Tests/KronosTests/NTPClientTests.swift
+++ b/Tests/KronosTests/NTPClientTests.swift
@@ -4,34 +4,43 @@ import XCTest
 @MainActor
 final class NTPClientTests: XCTestCase {
 
-    func testQueryIP() {
+    func testQueryIP() throws {
         let expectation = self.expectation(description: "NTPClient queries single IPs")
+        var unreachable = false
 
         DNSResolver.resolve(host: "time.apple.com") { addresses in
-            XCTAssertGreaterThan(addresses.count, 0)
+            guard let ip = addresses.first else {
+                unreachable = true
+                expectation.fulfill()
+                return
+            }
 
-            NTPClient().query(ip: addresses.first!, version: 3, numberOfSamples: 1) { PDU in
-                XCTAssertNotNil(PDU)
+            NTPClient().query(ip: ip, version: 3, numberOfSamples: 1) { PDU in
+                guard let PDU else {
+                    unreachable = true
+                    expectation.fulfill()
+                    return
+                }
 
-                XCTAssertGreaterThanOrEqual(PDU!.version, 3)
-                XCTAssertTrue(PDU!.isValidResponse())
-
+                XCTAssertGreaterThanOrEqual(PDU.version, 3)
+                XCTAssertTrue(PDU.isValidResponse())
                 expectation.fulfill()
             }
         }
 
         self.waitForExpectations(timeout: 10)
+        try XCTSkipIf(unreachable, "DNS/NTP unreachable (network/UDP 123 blocked?)")
     }
 
-    func testQueryPool() {
+    func testQueryPool() throws {
         let expectation = self.expectation(description: "Offset from ref clock to local clock are accurate")
-        NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
-            XCTAssertNotNil(offset)
+        var unreachable = false
 
+        NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
             NTPClient().query(pool: "0.pool.ntp.org", numberOfSamples: 1, maximumServers: 1)
             { offset2, _, _ in
                 guard let offset, let offset2 else {
-                    XCTFail("NTP query returned no offset (network/UDP 123 blocked?)")
+                    unreachable = true
                     expectation.fulfill()
                     return
                 }
@@ -41,15 +50,19 @@ final class NTPClientTests: XCTestCase {
         }
 
         self.waitForExpectations(timeout: 10)
+        try XCTSkipIf(unreachable, "NTP query returned no offset (network/UDP 123 blocked?)")
     }
 
-    func testQueryPoolWithIPv6() {
+    func testQueryPoolWithIPv6() throws {
         let expectation = self.expectation(description: "NTPClient queries a pool that supports IPv6")
+        var unreachable = false
+
         NTPClient().query(pool: "2.pool.ntp.org", numberOfSamples: 1, maximumServers: 1) { offset, _, _ in
-            XCTAssertNotNil(offset)
+            unreachable = offset == nil
             expectation.fulfill()
         }
 
         self.waitForExpectations(timeout: 10)
+        try XCTSkipIf(unreachable, "NTP query returned no offset (network/UDP 123 blocked?)")
     }
 }

--- a/Tests/KronosTests/NTPClientTests.swift
+++ b/Tests/KronosTests/NTPClientTests.swift
@@ -1,6 +1,7 @@
 import XCTest
 @testable import Kronos
 
+@MainActor
 final class NTPClientTests: XCTestCase {
 
     func testQueryIP() {

--- a/Tests/KronosTests/TimeStorageTests.swift
+++ b/Tests/KronosTests/TimeStorageTests.swift
@@ -37,8 +37,8 @@ class TimeStorageTests: XCTestCase {
         var storedData = sampleFreeze.toDictionary()
         storedData["Uptime"] = storedData["Uptime"]! + 10
 
-        let beforeRebootFreeze = TimeFreeze(from: sampleFreeze.toDictionary())
-        let afterRebootFreeze = TimeFreeze(from: storedData)
+        let beforeRebootFreeze = TimeFreeze(from: sampleFreeze.toDictionary(), log: nil)
+        let afterRebootFreeze = TimeFreeze(from: storedData, log: nil)
         XCTAssertNil(afterRebootFreeze)
         XCTAssertNotNil(beforeRebootFreeze)
     }


### PR DESCRIPTION
- Resolves: [PI-11469](https://prex.atlassian.net/browse/PI-11469) (parent epic [PI-8416](https://prex.atlassian.net/browse/PI-8416))

Bumps Kronos to `swift-tools-version:6.1` (Swift 6 language mode) and resolves the resulting fallout: the deprecated `String(cString:)` in `InternetAddress.host`, a now-redundant strict-concurrency flag, and test-target compile errors. Also hardens `InternetAddress.host` against a latent pointer-lifetime issue, adds comprehensive `InternetAddressTests` (the type was previously untested) including a before/after parity test, and makes the live network tests skip — rather than fail/crash — when NTP/DNS is unreachable.

<details>
  <summary>Why / context</summary>

- **`Package.swift`** — tools version `5.9` → `6.1`. In Swift 6 language mode strict concurrency is the default, so the test target's `.enableUpcomingFeature("StrictConcurrency")` setting is now redundant and was removed (the test target still compiles under strict concurrency — confirmed by build).
- **`InternetAddress.host`** — the array-based `String(cString: [CChar])` overload is deprecated. Replaced with the non-deprecated `UnsafePointer<CChar>` overload, built **inside** a scoped `withUnsafeMutableBufferPointer` and mapped over `inet_ntop`'s return value:
  - The string is decoded **inside** the closure, so the pointer `inet_ntop` returns (which aliases the buffer) never escapes the scope where the buffer is alive. (A variant that mapped over `inet_ntop(&buffer)` *outside* such a scope was rejected in review — that pointer can outlive its `&buffer` access, which is undefined behavior.)
  - `inet_ntop`'s result is `.map`-ped, not force-unwrapped, so the failure path degrades to `nil` rather than trapping the host app — a safer posture for a library. That path is unreachable anyway: `inet_ntop` can only fail on `EAFNOSUPPORT` (family is a hardcoded literal) or `ENOSPC` (buffer too small — sized to `INET*_ADDRSTRLEN`), neither possible here. Signature stays `String?` to match upstream Kronos and avoid churn in `Hashable`/`==`.
  - **Behavior-preserving vs `main`:** for every valid address both paths decode the same `inet_ntop` buffer up to the first NUL, so output is identical. The only divergence is the unreachable failure path (`nil` here vs `main`'s empty string), which no input can trigger. Proven by the parity test below.
- **Test target** — bumping to Swift 6 mode surfaced pre-existing errors: `XCTestCase`/`waitForExpectations` sendability and a missing `log:` argument. `ClockTests`/`DNSResolverTests`/`NTPClientTests` are isolated to `@MainActor` (their NTP/DNS callbacks already run on the main run loop, so this matches runtime behavior); `TimeFreeze(from:)` calls get the required `log: nil`. `ClockTests` is annotated `@available(*, deprecated, ...)` to suppress warnings for intentionally exercising the deprecated `Clock`.
- **`NTPClientTests`** — these are live integration tests (real DNS + NTP over UDP 123) and the only coverage of the `CFSocket`/`CFHost` I/O layer, which has no mockable seam. `testQueryIP` force-unwrapped `addresses.first!`/`PDU!`, which **crashes** (not just fails) when the network is blocked, since `XCTAssertNotNil` doesn't halt execution. All three tests now guard against a `nil` result and `XCTSkipIf` after `waitForExpectations`, so a UDP-123-blocked environment reports **skipped** instead of failed/crashed, while the real assertions (`isValidResponse`, two-query offset agreement within `0.10s`) still run when servers respond. Pre-existing test-hygiene fix, unrelated to the Swift 6 migration.
- **`DNSResolverTests.testResolveOneIP`** — `test.com` now has no A/AAAA records (global NODATA), so `XCTAssertEqual(addresses.count, 1)` could never pass on any network. This exact-count-against-a-third-party-domain pattern had already broken once before (the host was `lyft.com` until it grew extra A records, then was swapped to `test.com`). Switched to the IANA-reserved `example.com` (always resolves, never repurposed) and assert `> 0`; `testResolveMultipleIP` still covers the "many addresses" half of the original pair. Pre-existing fixture rot, unrelated to the Swift 6 migration.
- **`.gitignore`** — dropped the `.swiftpm/` line (kept out of scope per review).
- **`CLAUDE.md`** — added a Claude Code project guide describing the build/test commands, architecture, and conventions for this fork.
</details>

<details>
  <summary>Test plan</summary>

- `swift build --build-tests` — clean, no errors or warnings.
- `swift test` — **31 tests, 0 failures** on a network that allows outbound UDP 123.
- **Before/after parity:** `InternetAddressTests.testHostMatchesLegacyCStringDecoding` re-implements the pre-migration array-based decoding path (`legacyHost`) and asserts the new `inet_ntop` pointer path returns identical output across IPv4 (`0.0.0.0`, `127.0.0.1`, `192.168.1.1`, `255.255.255.255`, `8.8.8.8`) and IPv6 (`::`, `::1`, `2001:db8::1`, `fe80::1`, `ff02::1`, the longest all-`ffff` form, and IPv4-mapped `::ffff:255.255.255.255`).
- **Buffer-boundary invariant:** `testHostIsNonNilAtBufferSizeBoundary` proves the longest IPv4 string fits the tightest (`INET_ADDRSTRLEN`) buffer, so `inet_ntop` never hits `ENOSPC` and `host` stays non-`nil`.
- **New `InternetAddress` coverage:** equality (`==`), hashing (`Set` dedup), `init?(dataWithSockAddress:)` round-trips for IPv4/IPv6 plus the unsupported-family `nil` path, and `addressData(withPort:)` port encoding/round-trip.
- Deterministic suites (`InternetAddressTests`, `TimeStorageTests`, `TimeStoragePolicyTests`, `NTPPacketTests`) pass.
- Live network suites (`ClockTests`/`NTPClientTests`/`DNSResolverTests` resolve tests) pass on a permissive network and report **skipped** (not failed/crashed) where outbound UDP 123 / DNS is blocked.
</details>

## References
- Apple deprecation guidance — the array `String(cString:)` overload is deprecated; the `UnsafePointer<CChar>` overload used here is not: [swift stdlib CString.swift](https://github.com/apple/swift/blob/main/stdlib/public/core/CString.swift)
- Swift Evolution / stdlib change deprecating the buffer-based C-string initializers: [swiftlang/swift#68423](https://github.com/swiftlang/swift/pull/68423), [swiftlang/swift#71186](https://github.com/swiftlang/swift/pull/71186)


[PI-11469]: https://prex.atlassian.net/browse/PI-11469?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
[PI-8416]: https://prex.atlassian.net/browse/PI-8416?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
